### PR TITLE
Add mor Error handling

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,7 @@ import './App.css';
 import ArticlesByCategory from './components/ArticlesByCategory';
 import { UserContext } from './contexts/User';
 import { useState } from 'react';
+import ErrorsPage from './components/ErrorsPage';
 
 
 function App() {
@@ -22,6 +23,7 @@ function App() {
       <Route path="/articles/:topic" element={<ArticlesByCategory/>}/>
       <Route path="/article/:article_id" element={ <SingleArticle />}/>
       <Route path="/sign-in" element={ <ChangeUser/> }/>
+      <Route path="*" element={<ErrorsPage/>}/>
     </Routes>
   </UserContext.Provider>
   </BrowserRouter>

--- a/src/components/ArticlesByCategory.jsx
+++ b/src/components/ArticlesByCategory.jsx
@@ -3,19 +3,24 @@ import { useParams } from "react-router-dom";
 import { getAllArticles } from "./api";
 import Queries from "./ArticleQueryOptions";
 import AllArticlesCard from "./AllArticlesCard";
+import ErrorsPage from "./ErrorsPage";
 
 const ArticlesByCategory = () => {
   const { topic } = useParams();
   const [articles, setArticles] = useState([]);
   const [sortBy, setSortBy] = useState("created_at");
   const [orderBy, setOrderBy] = useState("desc");
+  const [err, setErr] = useState()
 
   useEffect(() => {
     getAllArticles(topic, sortBy, orderBy).then(({ allArticles }) => {
       setArticles(allArticles);
+    }).catch((err) => {
+      setErr(err)
     });
   }, [topic, sortBy, orderBy]);
 
+ if (err) return <ErrorsPage status={err.status} txt={err.txt} set={setErr}/>
 
   return (
     <div>

--- a/src/components/ErrorsPage.jsx
+++ b/src/components/ErrorsPage.jsx
@@ -1,0 +1,11 @@
+import { Link } from "react-router-dom";
+
+const ErrorsPage = ({status = 404, txt = "Not Found", setError}) => {
+
+    return <div>
+        <p>{status} {txt}</p>
+        <Link to="/" onClick={()=> setError(null)}>Go back to Home page</Link>
+        </div>
+}
+
+export default ErrorsPage;

--- a/src/components/SingleArticle.jsx
+++ b/src/components/SingleArticle.jsx
@@ -10,6 +10,7 @@ import {
   patchVotes,
   postNewComment,
 } from "./api";
+import ErrorsPage from "./ErrorsPage";
 import ExpandableComments from "./ExpandableComments";
 import ExpandCommentsForm from "./ExpandCommentsForm";
 import ExpndDeleteBtn from "./ExpndDeleteBtn";
@@ -31,10 +32,13 @@ const SingleArticle = () => {
 
   useEffect(() => {
     getArticleById(article_id).then(({ article }) => {
+      setErr(null)
       const articleCopy = { ...article };
       articleCopy.created_at = article.created_at.substring(0, 10);
       setArticle(articleCopy);
       setVotes(articleCopy.votes);
+    }).catch((err) => {
+      setErr(err)
     });
     getCommnetsByArticleId(article_id).then(({ allComments }) => {
       setComments(allComments);
@@ -92,7 +96,8 @@ const SingleArticle = () => {
 
   }
 
-  
+
+  if (err && err.status === 404) return <ErrorsPage status={err.status} txt={err.txt} set={setErr}/>
 
   return (
     <section>
@@ -117,6 +122,8 @@ const SingleArticle = () => {
               rows="6"
               cols="50"
               value={newComment}
+              minLength="5"
+              required
             ></textarea>
           </label>
           <input type="submit" value="Post!" />

--- a/src/components/api.jsx
+++ b/src/components/api.jsx
@@ -1,5 +1,6 @@
 import axios from "axios";
 
+
 export const getAllArticles = (topic, sortBy, orderBy) => {
 
  
@@ -7,8 +8,12 @@ export const getAllArticles = (topic, sortBy, orderBy) => {
     return fetch(
       `https://solveiga-nc-news-be.herokuapp.com/api/articles?topic=${topic}&sort_by=${sortBy}&order_by=${orderBy}`
     ).then((res) => {
+
+      if (!res.ok) {
+        return Promise.reject({status: res.status, txt: res.statusText})
+      }
       return res.json();
-    });
+    })
   } else {
     return fetch(`https://solveiga-nc-news-be.herokuapp.com/api/articles?sort_by=${sortBy}&order_by=${orderBy}`).then(
       (res) => {
@@ -30,6 +35,9 @@ export const getArticleById = (article_id) => {
   return fetch(
     `https://solveiga-nc-news-be.herokuapp.com/api/articles/${article_id}`
   ).then((res) => {
+    if (!res.ok) {
+      return Promise.reject({status: res.status, txt: res.statusText})
+    }
     return res.json();
   });
 };


### PR DESCRIPTION
Error handling for non existent path, article id or typed in topic link. Does not override other error messages that may appear when posting or deleting comment. User can only move on from error page by clicking go home link as that's what resets error state to null. Not sure if there was a better way of doing that